### PR TITLE
feat: user-logout & remove-user

### DIFF
--- a/src/main/java/org/app/user/config/KafkaConsumerConfig.java
+++ b/src/main/java/org/app/user/config/KafkaConsumerConfig.java
@@ -3,7 +3,8 @@ package org.app.user.config;
 import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.app.user.event.UserExistenceCheckedEvent;
+import org.app.user.event.UserRegisteredEvent;
+import org.app.user.event.UserRemovedEvent;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,6 +19,7 @@ import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 import java.util.HashMap;
 import java.util.Map;
+
 @Configuration
 @EnableKafka
 @RequiredArgsConstructor
@@ -26,12 +28,12 @@ public class KafkaConsumerConfig {
     private String bootstrapServers;
 
     @Bean
-    public ConsumerFactory<String, UserExistenceCheckedEvent> consumerFactory() {
-        JsonDeserializer<UserExistenceCheckedEvent> deserializer = new JsonDeserializer<>(UserExistenceCheckedEvent.class);
+    public ConsumerFactory<String, UserRegisteredEvent> consumerUserRegisteredFactory() {
+        JsonDeserializer<UserRegisteredEvent> deserializer = new JsonDeserializer<>(UserRegisteredEvent.class);
         deserializer.addTrustedPackages("*");
         deserializer.setUseTypeMapperForKey(false);
 
-        ErrorHandlingDeserializer<UserExistenceCheckedEvent> errorHandlingDeserializer = new ErrorHandlingDeserializer<>(deserializer);
+        ErrorHandlingDeserializer<UserRegisteredEvent> errorHandlingDeserializer = new ErrorHandlingDeserializer<>(deserializer);
 
         Map<String, Object> consumerConfig = new HashMap<>();
         consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
@@ -42,9 +44,33 @@ public class KafkaConsumerConfig {
     }
 
     @Bean
-    public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, UserExistenceCheckedEvent>> kafkaListenerContainerFactory(
-            ConsumerFactory<String, UserExistenceCheckedEvent> consumerFactory) {
-        ConcurrentKafkaListenerContainerFactory<String, UserExistenceCheckedEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+    public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, UserRegisteredEvent>> kafkaListenerContainerFactoryUserRegistered(
+            ConsumerFactory<String, UserRegisteredEvent> consumerFactory) {
+        ConcurrentKafkaListenerContainerFactory<String, UserRegisteredEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, UserRemovedEvent> consumerUserRemovedFactory() {
+        JsonDeserializer<UserRemovedEvent> deserializer = new JsonDeserializer<>(UserRemovedEvent.class);
+        deserializer.addTrustedPackages("*");
+        deserializer.setUseTypeMapperForKey(false);
+
+        ErrorHandlingDeserializer<UserRemovedEvent> errorHandlingDeserializer = new ErrorHandlingDeserializer<>(deserializer);
+
+        Map<String, Object> consumerConfig = new HashMap<>();
+        consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, errorHandlingDeserializer);
+
+        return new DefaultKafkaConsumerFactory<>(consumerConfig, new StringDeserializer(), errorHandlingDeserializer);
+    }
+
+    @Bean
+    public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, UserRemovedEvent>> kafkaListenerContainerFactoryUserRemoved(
+            ConsumerFactory<String, UserRemovedEvent> consumerFactory) {
+        ConcurrentKafkaListenerContainerFactory<String, UserRemovedEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory);
         return factory;
     }

--- a/src/main/java/org/app/user/config/KafkaProducerConfig.java
+++ b/src/main/java/org/app/user/config/KafkaProducerConfig.java
@@ -2,6 +2,7 @@ package org.app.user.config;
 
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.app.user.event.UserRemoveEvent;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
@@ -10,7 +11,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.beans.factory.annotation.Value;
 import org.app.user.event.UserRegistrationEvent;
-import org.app.user.event.CheckUserExistenceEvent;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,7 +30,7 @@ public class KafkaProducerConfig {
     }
 
     @Bean
-    public ProducerFactory<String, UserRegistrationEvent> userRegistrationEventProducerFactory() {
+    public ProducerFactory<String, UserRegistrationEvent> userRegisterationEventProducerFactory() {
         return new DefaultKafkaProducerFactory<>(producerConfig());
     }
 
@@ -41,13 +41,14 @@ public class KafkaProducerConfig {
     }
 
     @Bean
-    public ProducerFactory<String, CheckUserExistenceEvent> checkUserExistenceEventProducerFactory() {
+    public ProducerFactory<String, UserRemoveEvent> userRemoveEventProducerFactory() {
         return new DefaultKafkaProducerFactory<>(producerConfig());
     }
 
     @Bean
-    public KafkaTemplate<String, CheckUserExistenceEvent> checkUserExistenceEventKafkaTemplate(
-            ProducerFactory<String, CheckUserExistenceEvent> producerFactory) {
+    public KafkaTemplate<String, UserRemoveEvent> userRemoveEventKafkaTemplate(
+            ProducerFactory<String, UserRemoveEvent> producerFactory) {
         return new KafkaTemplate<>(producerFactory);
     }
 }
+

--- a/src/main/java/org/app/user/controller/AuthController.java
+++ b/src/main/java/org/app/user/controller/AuthController.java
@@ -3,25 +3,50 @@ package org.app.user.controller;
 import lombok.RequiredArgsConstructor;
 import org.app.user.event.UserLoginEvent;
 import org.app.user.event.UserRegistrationEvent;
+import org.app.user.event.UserRemoveEvent;
 import org.app.user.listener.AuthEventListener;
+import org.app.user.service.AuthService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 public class AuthController {
-
     private final AuthEventListener userEventListener;
+    private final AuthService authService;
+    private final Jwt userToken = (Jwt) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
     @PostMapping("/sign-up")
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<?> signUp(@RequestBody UserRegistrationEvent event) {
-        return ResponseEntity.ok(userEventListener.handleUserRegistration(event));
+        event.setCorrelationId(UUID.randomUUID().toString());
+        userEventListener.handleUserRegistration(event);
+        return ResponseEntity.ok("[User successfully signed up!]");
     }
 
     @PostMapping("/sign-in")
     public ResponseEntity<?> signIn(@RequestBody UserLoginEvent event) {
-        return userEventListener.handleUserLogin(event);
+        event.setCorrelationId(UUID.randomUUID().toString());
+        userEventListener.handleUserLogin(event);
+        return ResponseEntity.ok("[User successfully signed in!]");
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout() {
+        authService.logoutUser(userToken.getSubject());
+        return ResponseEntity.ok("[User successfully logged out from all sessions.]");
+    }
+
+    @PostMapping("/remove-user")
+    public ResponseEntity<?> removeUser(@RequestBody UserRemoveEvent event) {
+        event.setCorrelationId(UUID.randomUUID().toString());
+        userEventListener.handleUserRemove(event);
+        return ResponseEntity.ok("[User with ID: " + event.getUserId() + "successfully removed!]");
     }
 }

--- a/src/main/java/org/app/user/event/UserLogoutEvent.java
+++ b/src/main/java/org/app/user/event/UserLogoutEvent.java
@@ -7,9 +7,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class CheckUserExistenceEvent {
+public class UserLogoutEvent {
     private String correlationId;
-    private String username;
-    private String email;
+    private String userId;
 }
-

--- a/src/main/java/org/app/user/event/UserRegisteredEvent.java
+++ b/src/main/java/org/app/user/event/UserRegisteredEvent.java
@@ -7,8 +7,8 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class UserExistenceCheckedEvent {
+public class UserRegisteredEvent {
     private String correlationId;
+    private String userId;
     private boolean userExists;
 }
-

--- a/src/main/java/org/app/user/event/UserRegistrationEvent.java
+++ b/src/main/java/org/app/user/event/UserRegistrationEvent.java
@@ -9,8 +9,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UserRegistrationEvent {
     private String correlationId;
-    private String username;
+    private String userId;
     private String email;
+    private String username;
     private String password;
     private String bio;
 }

--- a/src/main/java/org/app/user/event/UserRemoveEvent.java
+++ b/src/main/java/org/app/user/event/UserRemoveEvent.java
@@ -7,8 +7,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class UserLoginEvent {
+public class UserRemoveEvent {
     private String correlationId;
-    private String username;
-    private String password;
+    private String userId;
 }

--- a/src/main/java/org/app/user/event/UserRemovedEvent.java
+++ b/src/main/java/org/app/user/event/UserRemovedEvent.java
@@ -7,8 +7,8 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class UserLoginEvent {
+public class UserRemovedEvent {
     private String correlationId;
-    private String username;
-    private String password;
+    private String userId;
+    private boolean userExists;
 }


### PR DESCRIPTION
- Implemented logout logic for invalidating user sessions in Keycloak.
- Added user removal logic for clean-up and deletion from Keycloak & your database.
- Updated logout endpoint to accept `sub` (from JWT bearer token) as `userId` when both the Keycloak and database user IDs are the same.